### PR TITLE
Fixes after project rename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.29)
 
-project(my-calc)
+project(my_calculator)
 # project name is provided in the variable CMAKE_PROJECT_NAME for use elsewhere
 
 # configuration (must be done after project() call)

--- a/cmake/packaging_tests.cmake
+++ b/cmake/packaging_tests.cmake
@@ -6,7 +6,7 @@ add_test(
   COMMAND
     ${CMAKE_SOURCE_DIR}/scripts/package_contents.bash
     ${CMAKE_CURRENT_BINARY_DIR}             # expect to find in this directory ..
-    "my-calc"                               # a .deb package (file) with package name "my-calc"
+    "my_calculator"                         # a .deb package (file) with package name "my-calc"
     "/usr/bin/calc"                         # containing the file /usr/bin/calc
 )
-set_tests_properties(expect_package_bin PROPERTIES LABELS "packaging;slow")
+set_tests_properties(check_package_contents PROPERTIES LABELS "packaging;slow")

--- a/devenv.bash
+++ b/devenv.bash
@@ -46,7 +46,7 @@ function script_body() {
 
   # 'dev-container' = service name as defined in compose file.
   # 'my_calc' = name of directory containing compose file
-  docker exec -it my_calc-dev-container-1 bash || true # evade set -e, to always print goodbye message
+  docker exec -it my_calculator-dev-container-1 bash || true # evade set -e, to always print goodbye message
   printf "\nclosing dev-env shell. You may want to stop the docker container process with\n\
 docker compose stop \n"
 }


### PR DESCRIPTION
[FIX] devenv.bash would try to connect to non-existing service (container) (name of referenced container was outdated)
[FIX] CMake project name not matching repo
[FIX] package content test name mismatches